### PR TITLE
OpenGLのバージョンが必要最低バージョンでない場合、エラーメッセージを出して終了するようにした

### DIFF
--- a/DesktopCharacter/View/Character.xaml
+++ b/DesktopCharacter/View/Character.xaml
@@ -18,6 +18,7 @@
         ShowInTaskbar="False"
         Topmost="True"
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
+        ContentRendered="Window_ContentRendered"
         Title="MainWindow" Height="400" Width="400"
         xmlns:sharpGL="clr-namespace:SharpGL.WPF;assembly=SharpGL.WPF">
     <Window.DataContext>

--- a/DesktopCharacter/View/Character.xaml.cs
+++ b/DesktopCharacter/View/Character.xaml.cs
@@ -85,13 +85,12 @@ namespace DesktopCharacter.View
         /// <param name="args">The <see cref="SharpGL.SceneGraph.OpenGLEventArgs"/> instance containing the event data.</param>
         private void OpenGLControl_OpenGLDraw(object sender, OpenGLEventArgs args)
         {
-#if DEBUG
             //!< Debugの時だけバージョンチェックをする
             if(RequiredVersion > GraphicsManager.Instance.GetVersion())
             {
                 return; //!< GL4.3以下なので処理をしない
             }
-#endif
+
             OpenGL gl = args.OpenGL;
             GraphicsManager Manager = GraphicsManager.Instance;
             Manager.Device = args.OpenGL;
@@ -132,13 +131,11 @@ namespace DesktopCharacter.View
         {
             GraphicsManager.Instance.Device = args.OpenGL;
             GraphicsManager.Instance.Initialize();
-#if DEBUG
             //!< Debugの時だけバージョンチェックをする
             if (RequiredVersion > GraphicsManager.Instance.GetVersion())
             {
                 return; //!< GL4.3以下なので処理をしない
             }
-#endif
             mLive2DManager.Load("Res/koharu", "koharu.model.json");
 
             mRenderTarget = new RenderTarget { Width = (uint)mScreenSize.X, Height = (uint)mScreenSize.Y };
@@ -156,7 +153,6 @@ namespace DesktopCharacter.View
 
         private void Window_ContentRendered(object sender, EventArgs e)
         {
-#if DEBUG
             //!< Debugの時だけバージョンチェックをする
             if (RequiredVersion > GraphicsManager.Instance.GetVersion())
             {
@@ -169,7 +165,6 @@ namespace DesktopCharacter.View
                 //!< アプリケーションを終了する
                 this.Close();
             }
-#endif
         }
     }
 }

--- a/DesktopCharacter/View/Character.xaml.cs
+++ b/DesktopCharacter/View/Character.xaml.cs
@@ -26,16 +26,38 @@ namespace DesktopCharacter.View
     /// </summary>
     public partial class Character : Window
     {
+        /// <summary>
+        /// スクリーンサイズ
+        /// </summary>
         System.Drawing.Point mScreenSize;
-
+        /// <summary>
+        /// xamlに渡すための書き込み先ビットマップ
+        /// </summary>
         WriteableBitmap mBitmapSource;
+        /// <summary>
+        /// 書き込み範囲（newの節約のためここでインスタンス化させる）
+        /// </summary>
         Int32Rect mSourceRect;
-
+        /// <summary>
+        /// レンダリングターゲット（テクスチャーに描画させるため）
+        /// </summary>
         RenderTarget mRenderTarget;
+        /// <summary>
+        /// Texture -> Bitmapのカラー情報
+        /// </summary>
         Shader mComputeShader;
+        /// <summary>
+        /// GLSLで使うBitmapのカラー情報格納先
+        /// </summary>
         SSBObject mSSBObject;
-
+        /// <summary>
+        /// Live2Dの管理クラス
+        /// </summary>
         Manager mLive2DManager = new Manager();
+        /// <summary>
+        /// デスクトップマスコットを利用するために必要なバージョン
+        /// </summary>
+        static double RequiredVersion = 4.3;
 
         public Character()
         {
@@ -63,6 +85,13 @@ namespace DesktopCharacter.View
         /// <param name="args">The <see cref="SharpGL.SceneGraph.OpenGLEventArgs"/> instance containing the event data.</param>
         private void OpenGLControl_OpenGLDraw(object sender, OpenGLEventArgs args)
         {
+#if DEBUG
+            //!< Debugの時だけバージョンチェックをする
+            if(RequiredVersion > GraphicsManager.Instance.GetVersion())
+            {
+                return; //!< GL4.3以下なので処理をしない
+            }
+#endif
             OpenGL gl = args.OpenGL;
             GraphicsManager Manager = GraphicsManager.Instance;
             Manager.Device = args.OpenGL;
@@ -102,6 +131,14 @@ namespace DesktopCharacter.View
         private void OpenGLControl_OpenGLInitialized(object sender, OpenGLEventArgs args)
         {
             GraphicsManager.Instance.Device = args.OpenGL;
+            GraphicsManager.Instance.Initialize();
+#if DEBUG
+            //!< Debugの時だけバージョンチェックをする
+            if (RequiredVersion > GraphicsManager.Instance.GetVersion())
+            {
+                return; //!< GL4.3以下なので処理をしない
+            }
+#endif
             mLive2DManager.Load("Res/koharu", "koharu.model.json");
 
             mRenderTarget = new RenderTarget { Width = (uint)mScreenSize.X, Height = (uint)mScreenSize.Y };
@@ -115,6 +152,24 @@ namespace DesktopCharacter.View
             mComputeShader.Attach();
 
             GraphicsManager.Instance.SetRenderTarget(mRenderTarget);
+        }
+
+        private void Window_ContentRendered(object sender, EventArgs e)
+        {
+#if DEBUG
+            //!< Debugの時だけバージョンチェックをする
+            if (RequiredVersion > GraphicsManager.Instance.GetVersion())
+            {
+                //!< GLのバージョンを表示してアプリケーションを終了する
+                MessageBox.Show(string.Format(
+                    "[ ERROR ]\nGL_VENDOR: {0} \nGL_RENDERER : {1} \nGL_VERSION : {2} \nOpenGLのバージョンが4.3以下です！コンピュートシェーダに対応していないため終了します",
+                    GraphicsManager.Instance.mVender,
+                    GraphicsManager.Instance.mRender,
+                    GraphicsManager.Instance.mVender));
+                //!< アプリケーションを終了する
+                this.Close();
+            }
+#endif
         }
     }
 }


### PR DESCRIPTION
バージョンが必要以上の場合無駄な
if分岐が無駄に走って処理が少し遅くなるかもしれない...（しかし、GLのスレッドが走るので必要...）
とりあえず、突然落ちるよりマシかと思ったので今の状態にした。

最終的には、エラーログを出力していらない分岐は消したほうがいいかもしれない？